### PR TITLE
Shut down VM when startup fails

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -201,7 +201,7 @@ function start_vm {
   startup_prelude="#!/bin/bash
   set -e
   shutdown() {
-    echo \"Machine setup failed; self deleting $VM_ID in ${machine_zone} ...\"
+    echo ❌ Machine setup failed; self deleting $VM_ID in ${machine_zone} ...
     ${shutdown_command}
   }
   trap shutdown EXIT

--- a/action.sh
+++ b/action.sh
@@ -201,7 +201,7 @@ function start_vm {
   startup_prelude="#!/bin/bash
   set -e
   shutdown() {
-    echo ❌ Machine setup failed; self deleting $VM_ID in ${machine_zone} ...
+    echo ❌ Machine setup failed so deleting $VM_ID in ${machine_zone} ...
     ${shutdown_command}
   }
   trap shutdown EXIT

--- a/action.sh
+++ b/action.sh
@@ -306,6 +306,8 @@ function start_vm {
   gh_repo="$(truncate_to_label "${GITHUB_REPOSITORY##*/}")"
   gh_run_id="${GITHUB_RUN_ID}"
 
+  set -e
+
   gcloud compute instances create ${VM_ID} \
     --zone=${machine_zone} \
     ${disk_size_flag} \

--- a/action.sh
+++ b/action.sh
@@ -242,7 +242,7 @@ function start_vm {
 	./svc.sh install && \\
 	./svc.sh start && \\
 	gcloud compute instances add-labels ${VM_ID} --zone=${machine_zone} --labels=gh_ready=1
-	# we cancel any workflows longer than 5 hours (was originally 3 days, the max workflow runtime)
+	# we cancel any workflows longer than 5 hours (was originally 3 days - the max workflow runtime)
 	nohup sh -c \"sleep 5h && ${shutdown_command}\" > /dev/null &
   "
 


### PR DESCRIPTION
Previously, startup errors were silently ignored; we now catch and shut down our VM on error. Also, the lines:

```
startup_script = "
# ... 
./bin/installdependencies.sh && \\
$startup_script"
```

meant that when installdependencies.sh fails the *first command* from the previous value of $startup_script would not run. This command was making shutdown.sh which means the machine was not able to shut itself down at the end of the job. We now let the trap catch this error instead. 